### PR TITLE
fix: path issue in windows "/" instead of "\"

### DIFF
--- a/src/vite-plugin.ts
+++ b/src/vite-plugin.ts
@@ -4,7 +4,8 @@ import {
     posix as posixPath,
     resolve as pathResolve,
     basename as pathBasename,
-    relative as pathRelative
+    relative as pathRelative,
+    normalize as pathNormalize
 } from "path";
 import type { Plugin, ResolvedConfig } from "vite";
 import { assert } from "tsafe/assert";
@@ -371,7 +372,9 @@ export function viteEnvs(params?: {
             } = resultOfConfigResolved;
 
             {
-                const isWithinSourceDirectory = id.startsWith(pathJoin(appRootDirPath, "src") + pathSep);
+                const isWithinSourceDirectory = pathNormalize(id).startsWith(
+                    pathNormalize(pathJoin(appRootDirPath, "src") + pathSep)
+                );
 
                 if (!isWithinSourceDirectory) {
                     return;


### PR DESCRIPTION
High there !

First, I appreciate this plugin 👍 

The plugin works well for html file but for js/ts/jsx/tsx, it doesn't work in windows environnement.

The issue du to path separator in windows, the `id` in tranform part of the plugin seem to not use the right sep.
I suggest this PR, i use `normalize` from `path` to fix this issue.

Fix: https://github.com/garronej/vite-envs/issues/22