### PR TITLE
Update README.md to be more explicit that the sh script is not actually optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ Making it work is as easy as updating your `Dockerfile` as follows:
 +ENTRYPOINT sh -c "./vite-envs.sh && nginx -g 'daemon off;'"
 ```  
 
-One thing to note is that running the `vite-envs.sh` script is fully optional.
-If you don't your app will still work as it normally would.  
+One thing to note is that running the `vite-envs.sh` script is only required to utilize this plugin, not all the time.
+If you don't use it, your app will still work as it normally would without dynamic environment variable support.  
 
 # Types  
 


### PR DESCRIPTION
Myself and another engineer who are using this plugin found the wording to be a bit confusing and made it seem as if you could just not use the shell script yet still use this plugin. Updated the wording to be a bit less ambiguous on what the purpose of the script is. 