### PR TITLE
Use globalThis instead of window

### DIFF
--- a/src/vite-plugin.ts
+++ b/src/vite-plugin.ts
@@ -398,7 +398,7 @@ export function viteEnvs(params?: {
                 /import\.meta\.env(?:\.([A-Za-z0-9$_]+)|\["([^"]+)"\]|(.?))/g,
                 (match, p1, p2, p3) => {
                     const out = (() => {
-                        const globalRef = `window.${nameOfTheGlobal}`;
+                        const globalRef = `globalThis.${nameOfTheGlobal}`;
 
                         if (p3 !== undefined) {
                             return `${globalRef}${p3}`;
@@ -703,7 +703,7 @@ export function viteEnvs(params?: {
                     `        ).slice(0,-1);`,
                     `        env[name] = value.startsWith(\\"${singularString2}\\") ? JSON.parse(value.slice(\\"${singularString2}\\".length)) : value;`,
                     `      });`,
-                    `      window.${nameOfTheGlobal} = env;`,
+                    `      globalThis.${nameOfTheGlobal} = env;`,
                     `    </script>"`,
                     ``,
                     `scriptPlaceholder="${placeholderForViteEnvsScript}"`,


### PR DESCRIPTION
Using window is not compatible with Web/Shared Workers (where window is undefined). Using globalThis is a better alternative, as it should work in all environments.