### PR TITLE
feat: enable overwriting nameOfTheGlobal

### DIFF
--- a/src/ViteEnvsMeta.ts
+++ b/src/ViteEnvsMeta.ts
@@ -5,4 +5,5 @@ export type ViteEnvsMeta = {
     declaredEnv: Record<string, string>;
     computedEnv: Record<string, unknown>;
     baseBuildTimeEnv: Record<string, unknown>;
+    nameOfTheGlobal?: string;
 };

--- a/src/bin/postBuildInjectionScript.ts
+++ b/src/bin/postBuildInjectionScript.ts
@@ -11,8 +11,16 @@ import { exclude } from "tsafe/exclude";
 import { createSwEnvJsFile } from "../createSwEnvJsFile";
 
 export async function postBuildInjectionScript() {
-    const { assetsUrlPath, baseBuildTimeEnv, declaredEnv, computedEnv, htmlPre }: ViteEnvsMeta =
-        JSON.parse(fs.readFileSync(pathJoin(process.cwd(), viteEnvsMetaFileBasename)).toString("utf8"));
+    const {
+        assetsUrlPath,
+        baseBuildTimeEnv,
+        declaredEnv,
+        computedEnv,
+        htmlPre,
+        nameOfTheGlobal
+    }: ViteEnvsMeta = JSON.parse(
+        fs.readFileSync(pathJoin(process.cwd(), viteEnvsMetaFileBasename)).toString("utf8")
+    );
 
     const mergedEnv = {
         ...Object.fromEntries(
@@ -61,10 +69,10 @@ export async function postBuildInjectionScript() {
 
     processedHtml = injectInHeadBeforeFirstScriptTag({
         "html": processedHtml,
-        "htmlToInject": getScriptThatDefinesTheGlobal({ "env": mergedEnv })
+        "htmlToInject": getScriptThatDefinesTheGlobal({ "env": mergedEnv, nameOfTheGlobal })
     });
 
     fs.writeFileSync(indexHtmlFilePath, Buffer.from(processedHtml, "utf8"));
 
-    createSwEnvJsFile({ "distDirPath": cwd, mergedEnv });
+    createSwEnvJsFile({ "distDirPath": cwd, mergedEnv, nameOfTheGlobal });
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,3 +1,3 @@
-export const nameOfTheGlobal = "__VITE_ENVS";
+export const defaultNameOfTheGlobal = "__VITE_ENVS";
 export const viteEnvsMetaFileBasename = ".vite-envs.json";
 export const updateTypingScriptEnvName = "__VITE_ENVS_UPDATE_TYPING_ENV";

--- a/src/createSwEnvJsFile.ts
+++ b/src/createSwEnvJsFile.ts
@@ -1,15 +1,16 @@
 import * as fs from "fs";
-import { nameOfTheGlobal } from "./constants";
+import { defaultNameOfTheGlobal } from "./constants";
 import { join as pathJoin } from "path";
 import { assert, is } from "tsafe";
 
 type Params = {
     distDirPath: string;
     mergedEnv: Record<string, unknown>;
+    nameOfTheGlobal?: string;
 };
 
 export function createSwEnvJsFile(params: Params) {
-    const { distDirPath, mergedEnv } = params;
+    const { distDirPath, mergedEnv, nameOfTheGlobal } = params;
 
     const envWithValuesInBase64 = Object.fromEntries(
         Object.entries(mergedEnv).map(([key, value]) => [
@@ -23,7 +24,9 @@ export function createSwEnvJsFile(params: Params) {
         `// It enables you to access environment variables in your service worker.`,
         `// To use it, use \`importScripts("swEnv.js")\` at the top of your worker file.`,
         `// (Assuming your worker file is next to this file)`,
-        `// Then you can access your environment variables via \`self.${nameOfTheGlobal}.MY_VAR\``,
+        `// Then you can access your environment variables via \`self.${
+            nameOfTheGlobal ?? defaultNameOfTheGlobal
+        }.MY_VAR\``,
         ``,
         `const envWithValuesInBase64 = ${JSON.stringify(envWithValuesInBase64, null, 2)
             .replace(/^"/, "")
@@ -39,7 +42,7 @@ export function createSwEnvJsFile(params: Params) {
         `      )`,
         `    );`,
         `});`,
-        `self.${nameOfTheGlobal} = env;`
+        `self.${nameOfTheGlobal ?? defaultNameOfTheGlobal} = env;`
     ].join("\n");
 
     try {

--- a/src/getScriptThatDefinesTheGlobal.ts
+++ b/src/getScriptThatDefinesTheGlobal.ts
@@ -1,7 +1,10 @@
-import { nameOfTheGlobal } from "./constants";
+import { defaultNameOfTheGlobal } from "./constants";
 
-export function getScriptThatDefinesTheGlobal(params: { env: Record<string, unknown> }): string {
-    const { env } = params;
+export function getScriptThatDefinesTheGlobal(params: {
+    env: Record<string, unknown>;
+    nameOfTheGlobal?: string;
+}): string {
+    const { env, nameOfTheGlobal } = params;
 
     const scriptPropertyKey = "data-script-description";
     const scriptPropertyValue = "Environment variables injected by vite-envs";
@@ -29,7 +32,7 @@ export function getScriptThatDefinesTheGlobal(params: { env: Record<string, unkn
         `      )`,
         `    );`,
         `  });`,
-        `  window.${nameOfTheGlobal} = env;`,
+        `  window.${nameOfTheGlobal ?? defaultNameOfTheGlobal} = env;`,
         `</script>`
     ].join("\n");
 


### PR DESCRIPTION
## Besoin

- pouvoir surcharger le nom de la variable global
- afin de permettre à une IHM mixant plusieurs IHM utilisant également la librairie `vite-envs` de ne pas écraser les variables d'environnements des autres IHM lors de l'usage du `swEnv.js`

## Solution proposée
- ajout d'un paramètre `nameOfTheGlobal` optionnel, permettant de donner un nom à cette variable.
- Par défaut, le nom de cette variable reste toujours `__VITE_ENVS` 