### PR TITLE
Change shell option to conditional based on OS

### DIFF
--- a/src/bin/updateTypes.ts
+++ b/src/bin/updateTypes.ts
@@ -2,12 +2,15 @@ import * as child_process from "child_process";
 import { updateTypingScriptEnvName } from "../constants";
 
 export async function updateTypes(): Promise<void> {
+
+    const isWindows = process.platform === "win32";                                                                                                                                                          
+    
     const child = child_process.spawn("npx", ["vite", "dev"], {
         env: {
             ...process.env,
             [updateTypingScriptEnvName]: ""
         },
-        shell: true
+        shell: isWindows
     });
 
     child.stdout.on("data", data => {

--- a/src/bin/updateTypes.ts
+++ b/src/bin/updateTypes.ts
@@ -2,9 +2,8 @@ import * as child_process from "child_process";
 import { updateTypingScriptEnvName } from "../constants";
 
 export async function updateTypes(): Promise<void> {
+    const isWindows = process.platform === "win32";
 
-    const isWindows = process.platform === "win32";                                                                                                                                                          
-    
     const child = child_process.spawn("npx", ["vite", "dev"], {
         env: {
             ...process.env,


### PR DESCRIPTION
`spawn("npx", ["vite", "dev"], { shell: true })` triggers Node.js DEP0190                                                                                                                                
  on macOS/Linux — passing an args array to a shell-mode spawn is flagged as                                                                                                                               
  a potential security issue (args are concatenated, not escaped).                                                                                                                                         
                                                                                                                                                                                                           
  `shell: true` is only needed on Windows where `npx` is a `.cmd` file and                                                                                                                                 
  cannot be spawned directly. On macOS/Linux, the binary is directly                                                                                                                                       
  executable.
  
  
`1095/1095(node:5155) [DEP0190] DeprecationWarning: Passing args to a child process with shell option true can lead to security vulnerabilities, as the arguments are not escaped, only concatenated. `