### PR TITLE
fix: use import attributes (`with`) instead of legacy import assertions

### DIFF
--- a/src/vite-plugin.ts
+++ b/src/vite-plugin.ts
@@ -7,7 +7,7 @@ import {
     relative as pathRelative,
     normalize as pathNormalize
 } from "path";
-import type { Plugin, ResolvedConfig } from "vite" assert { "resolution-mode": "import" };
+import type { Plugin, ResolvedConfig } from "vite" with { "resolution-mode": "import" };
 import { assert } from "tsafe/assert";
 import { typeGuard } from "tsafe/typeGuard";
 import { getThisCodebaseRootDirPath } from "./tools/getThisCodebaseRootDirPath";


### PR DESCRIPTION
Fixes #39

## What

One-line change in `src/vite-plugin.ts`:

```diff
-import type { Plugin, ResolvedConfig } from "vite" assert { "resolution-mode": "import" };
+import type { Plugin, ResolvedConfig } from "vite" with { "resolution-mode": "import" };
```

## Why

Import assertions were replaced by import attributes. TypeScript 6 and tsgo (`@typescript/native-preview`) reject the legacy `assert` keyword with a TS2880 grammar error while parsing the published `vite-plugin.d.ts`. Since it is a syntax error raised at parse time, `skipLibCheck: true` cannot suppress it, so any project importing `vite-envs` in its Vite config fails to type-check on TS 6.

The `with` syntax is supported since TypeScript 5.3, so consumers on ≥5.3 are unaffected. Verified locally (via `pnpm patch` of the published package) that this change resolves the error under `tsgo -b`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)